### PR TITLE
Fix shorstat shortname from t to s.

### DIFF
--- a/analysis/src/Invocation.java
+++ b/analysis/src/Invocation.java
@@ -60,7 +60,7 @@ public @CommandLineInterface interface Invocation {
     boolean getApplyFreeze();
 
   @Option(
-      shortName = "t",
+      shortName = "s",
       longName = "solvestats",
       description = "Print solvestats instead of file information")
     boolean getPrintSolvestats();


### PR DESCRIPTION
`t` is already used elsewhere and `s` seems better anyway?